### PR TITLE
Add showsEndOfRouteFeedback property

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ Array that contains the longitude and latitude for the destination point.<br>
 
 Boolean that controls route simulation. Set this as `true` to auto navigate which is useful for testing or demo purposes. Defaults to `false`.
 
+#### `showsEndOfRouteFeedback`
+
+Boolean that controls showing End of route Feedback UI when the route controller arrives at the final destination. Defaults to `true.`
+
 #### `onLocationChange`
 
 Function that is called frequently during route navigation. It receives `latitude` and `longitude` as parameters that represent the current location during navigation.

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ MapboxNavigation.propTypes = {
   onError: PropTypes.func,
   onCancelNavigation: PropTypes.func,
   onArrive: PropTypes.func,
+  showsEndOfRouteFeedback: PropTypes.bool,
 };
 
 const RNMapboxNavigation = requireNativeComponent(

--- a/ios/MapboxNavigationManager.m
+++ b/ios/MapboxNavigationManager.m
@@ -10,5 +10,6 @@ RCT_EXPORT_VIEW_PROPERTY(onArrive, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(origin, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(destination, NSArray)
 RCT_EXPORT_VIEW_PROPERTY(shouldSimulateRoute, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(showsEndOfRouteFeedback, BOOL)
 
 @end

--- a/ios/MapboxNavigationView.swift
+++ b/ios/MapboxNavigationView.swift
@@ -30,6 +30,7 @@ class MapboxNavigationView: UIView, NavigationViewControllerDelegate {
   }
   
   @objc var shouldSimulateRoute: Bool = false
+  @objc var showsEndOfRouteFeedback: Bool = true
   
   @objc var onLocationChange: RCTDirectEventBlock?
   @objc var onRouteProgressChange: RCTDirectEventBlock?
@@ -90,6 +91,8 @@ class MapboxNavigationView: UIView, NavigationViewControllerDelegate {
           
           let navigationOptions = NavigationOptions(navigationService: navigationService)
           let vc = NavigationViewController(for: route, routeIndex: 0, routeOptions: options, navigationOptions: navigationOptions)
+
+          vc.showsEndOfRouteFeedback = strongSelf.showsEndOfRouteFeedback
           
           vc.delegate = strongSelf
         


### PR DESCRIPTION
Hi!

_This is iOS only change._

I've added `showsEndOfRouteFeedback` property to allow showing/hiding end of route feedback UI on the iPhone.

Let me know if I missed anything. I specifically did not change anything for Android, because I was not able to find corresponding property in Android Navigation SDK. I found 

```Kotlin
 override fun onFinalDestinationArrival(enableDetailedFeedbackFlowAfterTbt: Boolean, enableArrivalExperienceFeedback: Boolean)
``` 

in the kotlin code (MapboxNavigationView.kt line 176) which seems like the Android equivalent, but I don't know enough Kotlin or Android development to expose it in the bridge. 