### PR TITLE
Bump Android SDK version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,8 +93,8 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.mapbox.navigation:core:1.3.0'
-    implementation 'com.mapbox.navigation:ui:1.3.0'
+    implementation 'com.mapbox.navigation:core:1.5.0'
+    implementation 'com.mapbox.navigation:ui:1.5.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 


### PR DESCRIPTION
Bumps the version of the Android SDKs to `1.5.0`, which removes the `ACCESS_BACKGROUND_LOCATION` permission