### PR TITLE
Applying customs styles to maneuver text

### DIFF
--- a/android/src/main/java/com/homee/mapboxnavigation/MapboxNavigationView.kt
+++ b/android/src/main/java/com/homee/mapboxnavigation/MapboxNavigationView.kt
@@ -335,6 +335,10 @@ class MapboxNavigationView(private val context: ThemedReactContext, private val 
             },
             {
                 binding.maneuverView.visibility = View.VISIBLE
+                binding.maneuverView.updatePrimaryManeuverTextAppearance(R.style.PrimaryManeuverTextAppearance)
+                binding.maneuverView.updateSecondaryManeuverTextAppearance(R.style.ManeuverTextAppearance)
+                binding.maneuverView.updateSubManeuverTextAppearance(R.style.ManeuverTextAppearance)
+                binding.maneuverView.updateStepDistanceTextAppearance(R.style.StepDistanceRemainingAppearance)
                 binding.maneuverView.renderManeuvers(maneuvers)
             }
         )

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,0 +1,15 @@
+<resources>
+    <style name="PrimaryManeuverTextAppearance" parent="TextAppearance.AppCompat">
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textSize">30sp</item>
+    </style>
+    <style name="ManeuverTextAppearance" parent="TextAppearance.AppCompat">
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">25sp</item>
+    </style>
+    <style name="StepDistanceRemainingAppearance" parent="TextAppearance.AppCompat">
+        <item name="android:textColor">#FFFFFF</item>
+        <item name="android:textSize">21sp</item>
+    </style>
+</resources>


### PR DESCRIPTION
We want to apply custom styles to the maneuver text. This PR applies text color, text weight, and text size from `styles.xml` to the maneuver text.

[Mapbox docs on the topic](https://docs.mapbox.com/android/navigation/guides/ui-components/maneuver/#change-the-text-properties)

![image](https://user-images.githubusercontent.com/1916208/153650212-a4f667b1-6f79-4611-bedf-a831ef51bffb.png) ![image](https://user-images.githubusercontent.com/1916208/153651085-84b97bea-f604-4b92-96fe-099fa76d0eae.png)


## Testing

| Device      | Emulator or Real device |Version | 
| ----------- | ----------- |----------- |
| Pixel 5   | Real device        |Android 12       | 

